### PR TITLE
Adding case-insensitive Culture name lookups against the JSON keys

### DIFF
--- a/Askmethat.Aspnet.JsonLocalizer/Localizer/JsonStringLocalizer.cs
+++ b/Askmethat.Aspnet.JsonLocalizer/Localizer/JsonStringLocalizer.cs
@@ -112,7 +112,7 @@ namespace Askmethat.Aspnet.JsonLocalizer.Localizer
                     var jsonValues = group
                         .Select(s => s.Values)
                         .SelectMany(dict => dict)
-                        .ToDictionary(t => t.Key, t => t.Value);
+                        .ToDictionary(t => t.Key, t => t.Value, StringComparer.OrdinalIgnoreCase);
 
                     tempLocalization.Add(new JsonLocalizationFormat()
                     {
@@ -195,7 +195,7 @@ namespace Askmethat.Aspnet.JsonLocalizer.Localizer
 
         string GetValueString(string name, CultureInfo cultureInfo)
         {
-            var query = localization.Where(l => l.Values.Keys.Any(lv => lv == cultureInfo.Name));
+            var query = localization.Where(l => l.Values.ContainsKey(cultureInfo.Name));
             var value = query.FirstOrDefault(l => l.Key == name);
 
 

--- a/test/Askmethat.Aspnet.JsonLocalizer.Test/Localizer/JsonStringLocalizerTest.cs
+++ b/test/Askmethat.Aspnet.JsonLocalizer.Test/Localizer/JsonStringLocalizerTest.cs
@@ -100,5 +100,29 @@ namespace Askmethat.Aspnet.JsonLocalizer.Test.Localizer
 
             Assert.AreEqual("My Base Name 1", result);
         }
+
+        [TestMethod]
+        public void Should_Read_CaseInsensitive_CultureName()
+        {
+            var sp = services.BuildServiceProvider();
+            var factory = sp.GetService<IStringLocalizerFactory>();
+            var localizer = factory.Create(typeof(IStringLocalizer));
+
+            CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+            var result = localizer.GetString("CaseInsensitiveCultureName");
+            Assert.AreEqual("French", result);
+        }
+
+        [TestMethod]
+        public void Should_Read_CaseInsensitive_UseDefault()
+        {
+            var sp = services.BuildServiceProvider();
+            var factory = sp.GetService<IStringLocalizerFactory>();
+            var localizer = factory.Create(typeof(IStringLocalizer));
+
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            var result = localizer.GetString("CaseInsensitiveCultureName");
+            Assert.AreEqual("US English", result);
+        }
     }
 }

--- a/test/Askmethat.Aspnet.JsonLocalizer.Test/Resources/localization.json
+++ b/test/Askmethat.Aspnet.JsonLocalizer.Test/Resources/localization.json
@@ -18,5 +18,12 @@
     "Values": {
       "en-US": "No more french"
     }
+  },
+  {
+    "Key": "CaseInsensitiveCultureName",
+    "Values": {
+      "en-us": "US English",
+      "FR-FR": "French"
+    }
   }
 ]


### PR DESCRIPTION
This PR allows culture-names specified within the JSON localization files to be case-insensitive. I believe this should be supported because .NET itself treats culture names case-insensitively (e.g. `new CultureInfo(name)`,  `CultureInfo.GetCulture(name)`,  etc.) by normalizing them behind-the-scenes.

For my own scenario, we have a a bunch of custom user-defined cultures registered on the server, which may have been entered like this: `"en-AU-ClientName"`.  Windows/.NET actually registers the name as `"en-AU-clientname"` but allows retrieving and using the culture by the name `"en-AU-ClientName"` or `"en-au-CLIENTNAME"` or however else a user might format its letter casing.