### PR TITLE
Support for parent-culture fallback

### DIFF
--- a/Askmethat.Aspnet.JsonLocalizer/Localizer/JsonFallbackStringLocalizer.cs
+++ b/Askmethat.Aspnet.JsonLocalizer/Localizer/JsonFallbackStringLocalizer.cs
@@ -1,0 +1,210 @@
+﻿using Askmethat.Aspnet.JsonLocalizer.Extensions;
+using Askmethat.Aspnet.JsonLocalizer.Format;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+
+
+namespace Askmethat.Aspnet.JsonLocalizer.Localizer
+{
+    /// <summary>
+    /// Json String localizer
+    /// Used to read JSON File and add it to cache ( default 30 minutes )
+    /// </summary>
+    internal class JsonFallbackStringLocalizer : IStringLocalizer
+    {
+        List<JsonLocalizationFormat> localization = new List<JsonLocalizationFormat>();
+        readonly IHostingEnvironment _env;
+        readonly IMemoryCache _memCache;
+        readonly IOptions<JsonLocalizationOptions> _localizationOptions;
+        readonly string _resourcesRelativePath;
+        readonly TimeSpan _memCacheDuration;
+        const string CACHE_KEY = "LocalizationBlob";
+
+        public JsonFallbackStringLocalizer(IHostingEnvironment env, IMemoryCache memCache, string resourcesRelativePath, IOptions<JsonLocalizationOptions> localizationOptions)
+        {
+            _env = env;
+            _memCache = memCache;
+            _resourcesRelativePath = resourcesRelativePath;
+            _localizationOptions = localizationOptions;
+            _memCacheDuration = _localizationOptions.Value.CacheDuration;
+            InitJsonStringLocalizer();
+        }
+
+
+        public JsonFallbackStringLocalizer(IHostingEnvironment env, IMemoryCache memCache, IOptions<JsonLocalizationOptions> localizationOptions)
+        {
+            _env = env;
+            _memCache = memCache;
+            _localizationOptions = localizationOptions;
+            _resourcesRelativePath = _localizationOptions.Value.ResourcesPath ?? String.Empty;
+            _memCacheDuration = _localizationOptions.Value.CacheDuration;
+
+            InitJsonStringLocalizer();
+        }
+
+        void InitJsonStringLocalizer()
+        {
+            string jsonPath = GetJsonRelativePath();
+
+            // Look for cache key.
+            if (!_memCache.TryGetValue(CACHE_KEY, out localization))
+            {
+                ConstructLocalizationObject(jsonPath);
+                // Set cache options.
+                var cacheEntryOptions = new MemoryCacheEntryOptions()
+                    // Keep in cache for this time, reset time if accessed.
+                    .SetSlidingExpiration(_memCacheDuration);
+
+                // Save data in cache.
+                _memCache.Set(CACHE_KEY, localization, cacheEntryOptions);
+            }
+        }
+
+        /// <summary>
+        /// Construct localization object from json files
+        /// </summary>
+        /// <param name="jsonPath">Json file path</param>
+        void ConstructLocalizationObject(string jsonPath)
+        {
+            //be sure that localization is always initialized
+            if (localization == null)
+            {
+                localization = new List<JsonLocalizationFormat>();
+            }
+
+            //get all files ending by json extension
+            var myFiles = Directory.GetFiles(jsonPath, "*.json", SearchOption.AllDirectories);
+
+            foreach (string file in myFiles)
+            {
+                localization.AddRange(JsonConvert.DeserializeObject<List<JsonLocalizationFormat>>(File.ReadAllText(file, _localizationOptions.Value.FileEncoding)));
+            }
+
+
+            MergeValues();
+
+        }
+
+        /// <summary>
+        /// Merge value to avoid duplicate culture in list
+        /// </summary>
+        void MergeValues()
+        {
+            var groups = localization.GroupBy(g => g.Key);
+
+            var tempLocalization = new List<JsonLocalizationFormat>();
+
+            foreach (var group in groups)
+            {
+                try
+                {
+                    var jsonValues = group
+                        .Select(s => s.Values)
+                        .SelectMany(dict => dict)
+                        .ToDictionary(t => t.Key, t => t.Value);
+
+                    tempLocalization.Add(new JsonLocalizationFormat()
+                    {
+                        Key = group.Key,
+                        Values = jsonValues
+                    });
+                }
+                catch (Exception e)
+                {
+                    throw new ArgumentException($"{group.Key} could not contains two translation for the same language code", e);
+                }
+
+            }
+
+            //merged values
+            localization = tempLocalization;
+        }
+
+        /// <summary>
+        /// Get path of json
+        /// </summary>
+        /// <returns>JSON relative path</returns>
+        string GetJsonRelativePath()
+        {
+            return !string.IsNullOrEmpty(_resourcesRelativePath) ? $"{GetBuildPath()}/{_resourcesRelativePath}/" : $"{_env.ContentRootPath}/Resources/";
+        }
+
+        string GetBuildPath()
+        {
+            return AppContext.BaseDirectory;
+        }
+
+        public LocalizedString this[string name]
+        {
+            get
+            {
+                var value = GetStringSafely(name);
+                return new LocalizedString(name, value ?? name, resourceNotFound: value == null);
+            }
+        }
+
+        public LocalizedString this[string name, params object[] arguments]
+        {
+            get
+            {
+                var format = GetStringSafely(name);
+                var value = String.Format(format ?? name, arguments);
+                return new LocalizedString(name, value, resourceNotFound: format == null);
+            }
+        }
+
+        public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures)
+        {
+            return includeParentCultures
+                ? localization
+                    .Select(
+                        l => {
+                            var value = GetStringSafely(l.Key);
+                            return new LocalizedString(l.Key, value ?? l.Key, resourceNotFound: value == null);
+                        }
+                    )
+                : localization
+                    .Where(l => l.Values.Keys.Any(lv => lv == CultureInfo.CurrentCulture.Name))
+                    .Select(l => new LocalizedString(l.Key, l.Values[CultureInfo.CurrentCulture.Name], false));
+        }
+
+        public IStringLocalizer WithCulture(CultureInfo culture)
+        {
+            return new JsonStringLocalizer(_env, _memCache, _resourcesRelativePath, _localizationOptions);
+        }
+
+        string GetStringSafely(string name, CultureInfo cultureInfo = null)
+        {
+            if (name == null) {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (cultureInfo == null) {
+                cultureInfo = CultureInfo.CurrentCulture;
+            }
+
+            var valuesSection = localization
+                .Where(l => l.Values.ContainsKey(cultureInfo.Name))
+                .FirstOrDefault(l => l.Key == name);
+
+            if (valuesSection != null) {
+                return valuesSection.Values[cultureInfo.Name];
+            }
+
+            if (!cultureInfo.Equals(cultureInfo.Parent)) {
+                //Try the parent culture
+                return GetStringSafely(name, cultureInfo.Parent);
+            }
+
+            return null;
+        }
+    }
+}

--- a/Askmethat.Aspnet.JsonLocalizer/Localizer/JsonStringLocalizerFactory.cs
+++ b/Askmethat.Aspnet.JsonLocalizer/Localizer/JsonStringLocalizerFactory.cs
@@ -41,12 +41,16 @@ namespace Askmethat.Aspnet.JsonLocalizer.Localizer
 
         public IStringLocalizer Create(Type resourceSource)
         {
-            return new JsonStringLocalizer(_env, _memCache, _resourcesRelativePath, _localizationOptions);
+            return _localizationOptions.Value.DefaultCulture != null
+                ? (IStringLocalizer)new JsonStringLocalizer(_env, _memCache, _resourcesRelativePath, _localizationOptions)
+                : (IStringLocalizer)new JsonFallbackStringLocalizer(_env, _memCache, _resourcesRelativePath, _localizationOptions);
         }
 
         public IStringLocalizer Create(string baseName, string location)
         {
-            return new JsonStringLocalizer(_env, _memCache, _resourcesRelativePath, _localizationOptions);
+            return _localizationOptions.Value.DefaultCulture != null
+                ? (IStringLocalizer)new JsonStringLocalizer(_env, _memCache, _resourcesRelativePath, _localizationOptions)
+                : (IStringLocalizer)new JsonFallbackStringLocalizer(_env, _memCache, _resourcesRelativePath, _localizationOptions);
         }
     }
 }

--- a/test/Askmethat.Aspnet.JsonLocalizer.Test/Askmethat.Aspnet.JsonLocalizer.Test.csproj
+++ b/test/Askmethat.Aspnet.JsonLocalizer.Test/Askmethat.Aspnet.JsonLocalizer.Test.csproj
@@ -39,6 +39,9 @@
     <None Update="encoding\localization.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="fallback\localization.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="json\localization.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/test/Askmethat.Aspnet.JsonLocalizer.Test/Localizer/FallbackJsonFileTest.cs
+++ b/test/Askmethat.Aspnet.JsonLocalizer.Test/Localizer/FallbackJsonFileTest.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.Collections;
+
+using Askmethat.Aspnet.JsonLocalizer.Extensions;
+using Askmethat.Aspnet.JsonLocalizer.TestSample;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Globalization;
+using System.Linq;
+
+using LocalizedString = Microsoft.Extensions.Localization.LocalizedString;
+
+
+namespace Askmethat.Aspnet.JsonLocalizer.Test.Localizer
+{
+    [TestClass]
+    public class FallbackJsonFileTest
+    {
+        IServiceCollection services;
+        TestServer server;
+
+        [TestInitialize]
+        public void Init()
+        {
+            var builder = new WebHostBuilder()
+                            .ConfigureServices(serv =>
+                            {
+                                serv.AddJsonLocalization(opt =>
+                                {
+                                    opt.ResourcesPath = "fallback";
+                                    opt.DefaultCulture = null;
+                                });
+                                this.services = serv;
+                            })
+                            .UseStartup<Startup>();
+
+            server = new TestServer(builder);
+
+        }
+
+        [TestMethod]
+        public void Should_Read_Color_NoFallback()
+        {
+            var sp = services.BuildServiceProvider();
+            var factory = sp.GetService<IStringLocalizerFactory>();
+            var localizer = factory.Create(typeof(IStringLocalizer));
+
+            SetCurrentCulture("en-AU");
+            var result = localizer.GetString("Color");
+            Assert.AreEqual("Colour (specific)", result);
+
+            SetCurrentCulture("fr");
+            result = localizer.GetString("Color");
+            Assert.AreEqual("Couleur (neutral)", result);
+
+            SetCurrentCulture(CultureInfo.InvariantCulture);
+            result = localizer.GetString("Color");
+            Assert.AreEqual("Color (invariant)", result);
+        }
+
+        [TestMethod]
+        public void Should_Read_Color_FallbackToParent()
+        {
+            var sp = services.BuildServiceProvider();
+            var factory = sp.GetService<IStringLocalizerFactory>();
+            var localizer = factory.Create(typeof(IStringLocalizer));
+
+            SetCurrentCulture("fr-FR");
+            var result = localizer.GetString("Color");
+            Assert.AreEqual("Couleur (neutral)", result);
+            Assert.IsFalse(result.ResourceNotFound);
+
+            SetCurrentCulture("en-NZ");
+            result = localizer.GetString("Color");
+            Assert.AreEqual("Color (neutral)", result);
+            Assert.IsFalse(result.ResourceNotFound);
+
+            SetCurrentCulture("zh-CN");
+            result = localizer.GetString("Color");
+            Assert.AreEqual("Color (invariant)", result);
+            Assert.IsFalse(result.ResourceNotFound);
+
+        }
+
+        [TestMethod]
+        public void Should_Read_ResourceMissingCulture_FallbackToResourceName()
+        {
+            var sp = services.BuildServiceProvider();
+            var factory = sp.GetService<IStringLocalizerFactory>();
+            var localizer = factory.Create(typeof(IStringLocalizer));
+
+            SetCurrentCulture("zh-CN");
+            var result = localizer.GetString("Empty");
+            Assert.AreEqual("Empty", result);
+            Assert.IsTrue(result.ResourceNotFound);
+        }
+
+        [TestMethod]
+        public void Should_Read_MissingResource_FallbackToResourceName()
+        {
+            var sp = services.BuildServiceProvider();
+            var factory = sp.GetService<IStringLocalizerFactory>();
+            var localizer = factory.Create(typeof(IStringLocalizer));
+
+            SetCurrentCulture("en-AU");
+            var result = localizer.GetString("No resource string");
+            Assert.AreEqual("No resource string", result);
+            Assert.IsTrue(result.ResourceNotFound);
+        }
+        
+        [TestMethod]
+        public void Should_Read_AllStringsWithParentFallback()
+        {
+            var sp = services.BuildServiceProvider();
+            var factory = sp.GetService<IStringLocalizerFactory>();
+            var localizer = factory.Create(typeof(IStringLocalizer));
+
+            SetCurrentCulture("en-AU");
+            var results = localizer.GetAllStrings(includeParentCultures: true).ToArray();
+            var expected = new[] {
+                new LocalizedString("Color", "Colour (specific)", false),
+                new LocalizedString("Empty", "Empty", false)
+            };
+            CollectionAssert.AreEqual(expected, results, new LocalizedStringComparer());
+        }
+
+        [TestMethod]
+        public void Should_Read_AllStringsWithoutParentFallback()
+        {
+            var sp = services.BuildServiceProvider();
+            var factory = sp.GetService<IStringLocalizerFactory>();
+            var localizer = factory.Create(typeof(IStringLocalizer));
+
+            SetCurrentCulture("en-AU");
+            var results = localizer.GetAllStrings(includeParentCultures: false).ToArray();
+            var expected = new[] {
+                new LocalizedString("Color", "Colour (specific)", false)
+            };
+            CollectionAssert.AreEqual(expected, results, new LocalizedStringComparer());
+        }
+
+        /// <summary>
+        /// LocalizedString doesn't implement the IComparer interface required by CollectionAssert.AreEqual(), so providing one here
+        /// </summary>
+        private class LocalizedStringComparer : IComparer
+        {
+            public int Compare(object x, object y)
+            {
+                var lsX = (LocalizedString)x;
+                var lsY = (LocalizedString)y;
+                if (ReferenceEquals(lsX, lsY)) {
+                    return 0;
+                }
+                if (lsX.Name == lsY.Name && lsX.Value == lsY.Value && lsX.ResourceNotFound == lsY.ResourceNotFound) {
+                    return 0;
+                }
+                int result = StringComparer.CurrentCulture.Compare(lsX.Name, lsY.Name);
+                if (result != 0) {
+                    return result;
+                }
+                result = StringComparer.CurrentCulture.Compare(lsX.Value, lsY.Value);
+                if (result != 0) {
+                    return result;
+                }
+                return lsX.ResourceNotFound.CompareTo(lsY.ResourceNotFound);
+            }
+        }
+
+        private void SetCurrentCulture(string cultureName)
+            => SetCurrentCulture(new CultureInfo(cultureName));
+
+        private void SetCurrentCulture(CultureInfo cultureInfo)
+            => CultureInfo.CurrentCulture = cultureInfo;
+    }
+}

--- a/test/Askmethat.Aspnet.JsonLocalizer.Test/fallback/localization.json
+++ b/test/Askmethat.Aspnet.JsonLocalizer.Test/fallback/localization.json
@@ -1,0 +1,17 @@
+[
+  {
+    "Key": "Color",
+    "Values": {
+      "": "Color (invariant)",
+      "en": "Color (neutral)",
+      "en-AU": "Colour (specific)",
+      "fr": "Couleur (neutral)"
+    }
+  },
+  {
+    "Key": "Empty",
+    "Values": {
+      "en": "Empty"
+    }
+  }
+]


### PR DESCRIPTION
Hi Alex,

Great job with this library!

This PR introduces what would have been breaking-changes to the current (`DefaultCulture`) fallback behaviour. To avoid that (I don't know whether you'd be happy to merge in a major breaking change just like that), I've implemented it in a new localizer class, `JsonFallbackStringLocalizer`, that's only used when `JsonLocalizationOptions.DefaultCulture` is set to null.

This localizer introduces fallback behaviour pretty-much identical, as far as I can tell, to the default StringLocalizer used by ASP.NET Core for RESX files, and similar to previous versions of .NET. The culture hierarchy is traversed until it finds a matching resource or reaches the Invariant culture.  See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/localization?view=aspnetcore-2.1#culture-fallback-behavior. If no string is found at all, then it returns the resource key name (and sets `LocalizedString.ResourceNotFound` to true).