### PR TITLE
Removing json loading and checking every request for better performance

### DIFF
--- a/Askmethat.Aspnet.JsonLocalizer/Localizer/IJsonStringLocalizer.cs
+++ b/Askmethat.Aspnet.JsonLocalizer/Localizer/IJsonStringLocalizer.cs
@@ -6,7 +6,8 @@ namespace Askmethat.Aspnet.JsonLocalizer.Localizer
 {
     public interface IJsonStringLocalizer: IStringLocalizer
     {
-        void ClearMemCache(IEnumerable<CultureInfo> culturesToClearFromCache = null);
+	    void ClearMemCache(IEnumerable<CultureInfo> culturesToClearFromCache = null);
+	    void ReloadMemCache(IEnumerable<CultureInfo> culturesToClearFromCache = null);
     }
 
     public interface IJsonStringLocalizer<T> : IJsonStringLocalizer

--- a/Askmethat.Aspnet.JsonLocalizer/Localizer/JsonStringLocalizer.cs
+++ b/Askmethat.Aspnet.JsonLocalizer/Localizer/JsonStringLocalizer.cs
@@ -123,6 +123,8 @@ namespace Askmethat.Aspnet.JsonLocalizer.Localizer
 
             if (shouldTryDefaultCulture)
             {
+	            InitJsonStringLocalizer(_localizationOptions.Value.DefaultCulture);
+	            AddMissingCultureToSupportedCulture(_localizationOptions.Value.DefaultCulture);
                 GetCultureToUse(_localizationOptions.Value.DefaultCulture);
                 return GetString(name, false);
             }

--- a/Askmethat.Aspnet.JsonLocalizer/Localizer/JsonStringLocalizer.cs
+++ b/Askmethat.Aspnet.JsonLocalizer/Localizer/JsonStringLocalizer.cs
@@ -20,7 +20,7 @@ namespace Askmethat.Aspnet.JsonLocalizer.Localizer
             _env = env;
             resourcesRelativePath = GetJsonRelativePath(_localizationOptions.Value.ResourcesPath);
 
-            InitJsonStringLocalizer();
+            //InitJsonStringLocalizer();
         }
 
         public LocalizedString this[string name]

--- a/Askmethat.Aspnet.JsonLocalizer/Localizer/JsonStringLocalizer.cs
+++ b/Askmethat.Aspnet.JsonLocalizer/Localizer/JsonStringLocalizer.cs
@@ -175,5 +175,22 @@ namespace Askmethat.Aspnet.JsonLocalizer.Localizer
                 _memCache.Remove(GetCacheKey(cultureInfo));
             }
         }
+
+        /// <summary>
+        /// Reload memory cache
+        /// </summary>
+        /// <param name="reloadCulturesToCache">Reload specified cultures</param>
+
+        public void ReloadMemCache(IEnumerable<CultureInfo> reloadCulturesToCache = null)
+        {
+	        ClearMemCache();
+	        foreach (var cultureInfo in reloadCulturesToCache ??
+	                                    _localizationOptions.Value.SupportedCultureInfos.ToArray())
+	        {
+		        InitJsonStringLocalizer(cultureInfo);
+		        AddMissingCultureToSupportedCulture(cultureInfo);
+		        GetCultureToUse(cultureInfo);
+            }
+        }
     }
 }

--- a/Askmethat.Aspnet.JsonLocalizer/Localizer/JsonStringLocalizerBase.cs
+++ b/Askmethat.Aspnet.JsonLocalizer/Localizer/JsonStringLocalizerBase.cs
@@ -70,20 +70,20 @@ namespace Askmethat.Aspnet.JsonLocalizer.Localizer
         #endregion
 
         #region files initialization
-        
-        protected void InitJsonStringLocalizer()
-        {
-            AddMissingCultureToSupportedCulture(CultureInfo.CurrentUICulture);
-            AddMissingCultureToSupportedCulture(_localizationOptions.Value.DefaultCulture);
 
-            foreach (CultureInfo ci in _localizationOptions.Value.SupportedCultureInfos)
-            {
-                InitJsonStringLocalizer(ci);
-            }
+        //protected void InitJsonStringLocalizer()
+        //{
+        //    AddMissingCultureToSupportedCulture(CultureInfo.CurrentUICulture);
+        //    AddMissingCultureToSupportedCulture(_localizationOptions.Value.DefaultCulture);
 
-            //after initialization, get current ui culture
-            GetCultureToUse(CultureInfo.CurrentUICulture);
-        }
+        //    foreach (CultureInfo ci in _localizationOptions.Value.SupportedCultureInfos)
+        //    {
+        //        InitJsonStringLocalizer(ci);
+        //    }
+
+        //    // after initialization, get current ui culture
+        //    GetCultureToUse(CultureInfo.CurrentUICulture);
+        //}
 
         protected void AddMissingCultureToSupportedCulture(CultureInfo cultureInfo)
         {
@@ -192,7 +192,7 @@ namespace Askmethat.Aspnet.JsonLocalizer.Localizer
                         searchPattern = $"{shortName}?.json";
                     }
                 }
-
+					
                 files = Directory.GetFiles(basePath, searchPattern, searchOption).ToList();
                 //add sharedfile that should be found in base path
                 files.AddRange(Directory.GetFiles(basePath, sharedSearchPattern, SearchOption.TopDirectoryOnly));

--- a/benchmark/Askmethat.Aspnet.JsonLocalizer.Benchmark/Program.cs
+++ b/benchmark/Askmethat.Aspnet.JsonLocalizer.Benchmark/Program.cs
@@ -45,13 +45,6 @@ namespace Askmethat.Aspnet.JsonLocalizer.Benchmark
                 ResourcesPath = "Resources",
                 Caching = _cach2
             }), new HostingEnvironmentStub());
-
-            // Simulate the first web request.
-            // Ignore *.json loading in test.
-            CultureInfo.CurrentUICulture = new CultureInfo("pt-PT");
-            _ = _jsonLocalizer.GetString("BaseName1").Value;
-            CultureInfo.CurrentUICulture = new CultureInfo("fr-FR");
-            _ = _jsonLocalizer.GetString("BaseName1").Value;
         }
 
         [Benchmark(Baseline = true)]

--- a/benchmark/Askmethat.Aspnet.JsonLocalizer.Benchmark/Program.cs
+++ b/benchmark/Askmethat.Aspnet.JsonLocalizer.Benchmark/Program.cs
@@ -45,6 +45,13 @@ namespace Askmethat.Aspnet.JsonLocalizer.Benchmark
                 ResourcesPath = "Resources",
                 Caching = _cach2
             }), new HostingEnvironmentStub());
+
+            // Simulate the first web request.
+            // Ignore *.json loading in test.
+            CultureInfo.CurrentUICulture = new CultureInfo("pt-PT");
+            _ = _jsonLocalizer.GetString("BaseName1").Value;
+            CultureInfo.CurrentUICulture = new CultureInfo("fr-FR");
+            _ = _jsonLocalizer.GetString("BaseName1").Value;
         }
 
         [Benchmark(Baseline = true)]

--- a/test/Askmethat.Aspnet.JsonLocalizer.TestSample/Controllers/ReloadController.cs
+++ b/test/Askmethat.Aspnet.JsonLocalizer.TestSample/Controllers/ReloadController.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using Askmethat.Aspnet.JsonLocalizer.Localizer;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Askmethat.Aspnet.JsonLocalizer.TestSample.Controllers
+{
+    public class ReloadController : Controller
+    {
+        private readonly IJsonStringLocalizer _localizer;
+        public ReloadController(IJsonStringLocalizer<ReloadController> localizer)
+        {
+            _localizer = localizer;
+        }
+        public IActionResult Index()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        public IActionResult ReloadCultures(string culture, string returnUrl)
+        {
+	        _localizer.ReloadMemCache(new List<CultureInfo>()
+	        {
+		        new CultureInfo(culture)
+	        });
+
+            return LocalRedirect(returnUrl);
+        }
+
+    }
+}

--- a/test/Askmethat.Aspnet.JsonLocalizer.TestSample/Views/Reload/Index.cshtml
+++ b/test/Askmethat.Aspnet.JsonLocalizer.TestSample/Views/Reload/Index.cshtml
@@ -1,0 +1,35 @@
+﻿@{
+    ViewData["Title"] = Localizer["Reload"];
+}
+@using Askmethat.Aspnet.JsonLocalizer.TestSample
+@using System.Threading.Tasks
+@using Microsoft.AspNetCore.Builder
+@using Microsoft.AspNetCore.Localization
+@using Microsoft.AspNetCore.Mvc.Localization
+@using Microsoft.Extensions.Options
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+@inject IOptions<RequestLocalizationOptions> LocOptions
+@inject IViewLocalizer Localizer
+
+
+<h2>Askmethat.Aspnet.JsonLocalizer</h2>
+
+
+@{
+    var requestCulture = Context.Features.Get<IRequestCultureFeature>();
+    var cultureItems = LocOptions.Value.SupportedUICultures
+        .Select(c => new SelectListItem {Value = c.Name, Text = Localizer[c.Name].Value})
+        .ToList();
+
+}
+
+<div>
+    <form id="selectLanguage" asp-controller="Reload"
+          asp-action="ReloadCultures" asp-route-returnUrl="@Context.Request.Path"
+          method="post" class="form-horizontal" role="form">
+        @Localizer["Language"] <select name="culture" asp-for="@requestCulture.RequestCulture.UICulture.Name" asp-items="cultureItems"></select>
+        <button type="submit" class="btn btn-default btn-xs">@Localizer["Reload"]</button>
+
+    </form>
+</div>

--- a/test/Askmethat.Aspnet.JsonLocalizer.TestSample/json/Views/Home/Reload/Index.json
+++ b/test/Askmethat.Aspnet.JsonLocalizer.TestSample/json/Views/Home/Reload/Index.json
@@ -1,0 +1,7 @@
+﻿{
+  "Reload": {
+    "Values": {
+      "en-US": "Reload Cultures"
+    }
+  }
+}


### PR DESCRIPTION
Hi.

After analyzing the program, I came to the conclusion that the InitJsonStringLocalizer method is not required.

The first web request loads the default and current language, and store in MemoryCache.
After the change:

JsonLocalizer 1.4% - 27.3% faster.
JsonLocalizerWithCreation 46.5% - 49.8% faster.
JsonLocalizerWithCreationAndExternalMemoryCache 11.8% - 14% faster.
JsonLocalizerDefaultCultureValue 0.6% - 8.1% faster.

Benchmark files:

Build release

1 Build master
2 Reboot, after five minutes start the test

[First start](https://github.com/AlexTeixeira/Askmethat-Aspnet-JsonLocalizer/files/4303339/Askmethat.Aspnet.JsonLocalizer.Benchmark.BenchmarkJSONLocalizer-20200308-143231.log)
[Second start](https://github.com/AlexTeixeira/Askmethat-Aspnet-JsonLocalizer/files/4303335/Askmethat.Aspnet.JsonLocalizer.Benchmark.BenchmarkJSONLocalizer-20200308-143549.log)

1 Remove InitJsonStringLocalizer
2 Build SpeedUp
3 Reboot, after five minutes start the test

[First start](https://github.com/AlexTeixeira/Askmethat-Aspnet-JsonLocalizer/files/4303337/Askmethat.Aspnet.JsonLocalizer.Benchmark.BenchmarkJSONLocalizer-20200308-144605.log)
[Second start](https://github.com/AlexTeixeira/Askmethat-Aspnet-JsonLocalizer/files/4303338/Askmethat.Aspnet.JsonLocalizer.Benchmark.BenchmarkJSONLocalizer-20200308-144927.log)

1 Add default language load patch
2 Build SpeedUp
3 Reboot, after five minutes start the test

[First start](https://github.com/AlexTeixeira/Askmethat-Aspnet-JsonLocalizer/files/4303955/Askmethat.Aspnet.JsonLocalizer.Benchmark.BenchmarkJSONLocalizer-20200308-220909.log)
[Second start](https://github.com/AlexTeixeira/Askmethat-Aspnet-JsonLocalizer/files/4303956/Askmethat.Aspnet.JsonLocalizer.Benchmark.BenchmarkJSONLocalizer-20200308-221342.log)




