### PR TITLE
added support to split i18n files into multiple json files 

### DIFF
--- a/Askmethat.Aspnet.JsonLocalizer/Localizer/Modes/LocalizationI18NModeGenerator.cs
+++ b/Askmethat.Aspnet.JsonLocalizer/Localizer/Modes/LocalizationI18NModeGenerator.cs
@@ -29,8 +29,8 @@ namespace Askmethat.Aspnet.JsonLocalizer.Localizer.Modes
             _options = options;
 
             var enumerable = myFiles as string[] ?? myFiles.ToArray();
-            var neutralFile = enumerable.FirstOrDefault(file => Path.GetFileName(file)
-                .Count(s => s.CompareTo('.') == 0) == 1);
+            var neutralFiles = enumerable.Where(file => Path.GetFileName(file)
+                .Count(s => s.CompareTo('.') == 0) == 1).ToList();
             var isInvariantCulture =
                 currentCulture.DisplayName == CultureInfo.InvariantCulture.ThreeLetterISOLanguageName;
 
@@ -61,9 +61,10 @@ namespace Askmethat.Aspnet.JsonLocalizer.Localizer.Modes
             }
             else
             {
-                if (neutralFile != null)
+                if (neutralFiles.Any())
                 {
-                    AddValueToLocalization(options, neutralFile, true);
+                    foreach (var neutralFile in neutralFiles)
+                        AddValueToLocalization(options, neutralFile, true);
                 }
             }
 

--- a/test/Askmethat.Aspnet.JsonLocalizer.I18nTestSample/i18n/localization.en-US.json
+++ b/test/Askmethat.Aspnet.JsonLocalizer.I18nTestSample/i18n/localization.en-US.json
@@ -8,16 +8,8 @@
   "WeatherForecastDesc": "This component demonstrates fetching data from a service.",
   "Loading": "Loading...",
   "Date": "Date",
-  "TempC": "Temp. (C)",
-  "TempF": "Temp. (F)",
   "Summary": "Summary",
   "CurrentCount": "Current count",
   "ClickMe": "Click me",
-  "About": "About",
-  "Freezing": "Freezing",
-  "Bracing": "Bracing",
-  "Chilly": "Chilly",
-  "Cool": "Cool",
-  "Mild": "Mild",
-  "Warm": "Warm"
+  "About": "About"
 }

--- a/test/Askmethat.Aspnet.JsonLocalizer.I18nTestSample/i18n/localization.fr-FR.json
+++ b/test/Askmethat.Aspnet.JsonLocalizer.I18nTestSample/i18n/localization.fr-FR.json
@@ -8,16 +8,8 @@
   "WeatherForecastDesc": "Ce volet montre comment obtenir des données à partir d'un service.",
   "Loading": "Chargement...",
   "Date": "Date",
-  "TempC": "Temp. (C)",
-  "TempF": "Temp. (F)",
   "Summary": "Sommaire",
   "CurrentCount": "Valeur courante",
   "ClickMe": "Cliquer",
-  "About": "À propos de",
-  "Freezing": "Geler",
-  "Bracing": "Bracing",
-  "Chilly": "Froid",
-  "Cool": "Frais",
-  "Mild": "Doux",
-  "Warm": "Chaud"
+  "About": "À propos de"
 }

--- a/test/Askmethat.Aspnet.JsonLocalizer.I18nTestSample/i18n/temperatures.en-US.json
+++ b/test/Askmethat.Aspnet.JsonLocalizer.I18nTestSample/i18n/temperatures.en-US.json
@@ -1,0 +1,10 @@
+{
+  "TempC": "Temp. (C)",
+  "TempF": "Temp. (F)",
+  "Freezing": "Freezing",
+  "Bracing": "Bracing",
+  "Chilly": "Chilly",
+  "Cool": "Cool",
+  "Mild": "Mild",
+  "Warm": "Warm"
+}

--- a/test/Askmethat.Aspnet.JsonLocalizer.I18nTestSample/i18n/temperatures.fr-FR.json
+++ b/test/Askmethat.Aspnet.JsonLocalizer.I18nTestSample/i18n/temperatures.fr-FR.json
@@ -1,0 +1,10 @@
+{
+  "TempC": "Temp. (C)",
+  "TempF": "Temp. (F)",
+  "Freezing": "Geler",
+  "Bracing": "Bracing",
+  "Chilly": "Froid",
+  "Cool": "Frais",
+  "Mild": "Doux",
+  "Warm": "Chaud"
+}

--- a/test/Askmethat.Aspnet.JsonLocalizer.Test/Localizer/I18nFallbackJsonFileTest.cs
+++ b/test/Askmethat.Aspnet.JsonLocalizer.Test/Localizer/I18nFallbackJsonFileTest.cs
@@ -70,6 +70,26 @@ namespace Askmethat.Aspnet.JsonLocalizer.Test.Localizer
 
         }
 
+        [TestMethod]
+        public void Should_Read_Luminosity_FallbackToParent()
+        {
+            InitLocalizer("fr-FR");
+            LocalizedString result = localizer.GetString("Luminosity");
+            Assert.AreEqual("Luminosité", result);
+            Assert.IsFalse(result.ResourceNotFound);
+
+            InitLocalizer("en-NZ");
+            result = localizer.GetString("Luminosity");
+            Assert.AreEqual("Luminosity", result);
+            Assert.IsFalse(result.ResourceNotFound);
+
+            InitLocalizer("zh-CN");
+            result = localizer.GetString("Luminosity");
+            Assert.AreEqual("Luminosity", result);
+            Assert.IsFalse(result.ResourceNotFound);
+
+        }
+
         //[TestMethod]
         public void Should_Read_ResourceMissingCulture_FallbackToResourceName()
         {
@@ -97,7 +117,8 @@ namespace Askmethat.Aspnet.JsonLocalizer.Test.Localizer
             LocalizedString[] results = localizer.GetAllStrings(includeParentCultures: true).ToArray();
             LocalizedString[] expected = new[] {
                 new LocalizedString("Color", "Colour (specific)", false),
-                new LocalizedString("Empty", "Empty", false)
+                new LocalizedString("Empty", "Empty", false),
+                new LocalizedString("Luminosity", "Luminosity", false)
             };
             CollectionAssert.AreEqual(expected, results.OrderBy(s => s.Name).ToArray(), new LocalizedStringComparer());
         }

--- a/test/Askmethat.Aspnet.JsonLocalizer.Test/i18nFallback/localizationFile2.en.json
+++ b/test/Askmethat.Aspnet.JsonLocalizer.Test/i18nFallback/localizationFile2.en.json
@@ -1,0 +1,3 @@
+﻿{
+  "Luminosity" : "Luminosity"
+}

--- a/test/Askmethat.Aspnet.JsonLocalizer.Test/i18nFallback/localizationFile2.fr.json
+++ b/test/Askmethat.Aspnet.JsonLocalizer.Test/i18nFallback/localizationFile2.fr.json
@@ -1,0 +1,3 @@
+﻿{
+  "Luminosity": "Luminosité"
+}

--- a/test/Askmethat.Aspnet.JsonLocalizer.Test/i18nFallback/localizationFile2.json
+++ b/test/Askmethat.Aspnet.JsonLocalizer.Test/i18nFallback/localizationFile2.json
@@ -1,0 +1,3 @@
+﻿{
+  "Luminosity" : "Luminosity"
+}


### PR DESCRIPTION
We have adopted the i18n structure for several projects but as the projects expand, our json files become unmanageable. This patch enables to split the massive files into multiple - e.g. by domain - to be able to manage each file separately.

Added unit tests, and example where the temperature localization is split into multiple files.