### PR TITLE
Collect missing to json

### DIFF
--- a/Askmethat.Aspnet.JsonLocalizer/Extensions/MissingTranslationLogBehavior.cs
+++ b/Askmethat.Aspnet.JsonLocalizer/Extensions/MissingTranslationLogBehavior.cs
@@ -3,6 +3,7 @@
     public enum MissingTranslationLogBehavior
     {
         Ignore,
-        LogConsoleError
+        LogConsoleError,
+        CollectToJSON
     }
 }

--- a/Askmethat.Aspnet.JsonLocalizer/JsonOptions/JsonLocalizationOptions.cs
+++ b/Askmethat.Aspnet.JsonLocalizer/JsonOptions/JsonLocalizationOptions.cs
@@ -14,6 +14,7 @@ namespace Askmethat.Aspnet.JsonLocalizer.JsonOptions
         private const char PLURAL_SEPARATOR = '|';
         private const string DEFAULT_RESOURCES = "Resources";
         private const string DEFAULT_CULTURE = "en-US";
+        public const string DEFAULT_MISSING_TRANSLATIONS = "MissingTranslations.json";
 
         public new string ResourcesPath { get; set; } = DEFAULT_RESOURCES;
         /// We cache all values to memory to avoid loading files for each request, this parameter defines the time after which the cache is refreshed.
@@ -120,5 +121,10 @@ namespace Askmethat.Aspnet.JsonLocalizer.JsonOptions
         /// Define JSON Files management. See documentation for more information
         /// </summary>
         public LocalizationMode LocalizationMode { get; set; } = LocalizationMode.Basic;
+
+        /// <summary>
+        /// Local file name where the missing translation JSON values can be written. See documentation for more information
+        /// </summary>
+        public string MissingTranslationsOutputFile { get; internal set; } = DEFAULT_MISSING_TRANSLATIONS;
     }
 }

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ services.AddJsonLocalization(options => {
 - **PluralSeparator** : *_default value: |*. Seperator used to get singular or pluralized version of localization. More information in *Pluralization*
 - **MissingTranslationLogBehavior** : *_default value: LogConsoleError*. Define the logging mode
 - **LocalizationMode** : *_default value: Basic*. Define the localization mode for the Json file. Currently Basic and I18n. More information in *LocalizationMode*
+- **MissingTranslationsOutputFile** : This enables to specify in which file the missing translations will be written when `MissingTranslationLogBehavior = MissingTranslationLogBehavior.CollectToJSON`, defaults to `MissingTranslations.json`
 
 ### Search patterns when UseBaseName = true
 

--- a/test/Askmethat.Aspnet.JsonLocalizer.Test/Localizer/MissingTranslationsTest.cs
+++ b/test/Askmethat.Aspnet.JsonLocalizer.Test/Localizer/MissingTranslationsTest.cs
@@ -1,0 +1,85 @@
+﻿using Askmethat.Aspnet.JsonLocalizer.Localizer;
+using Askmethat.Aspnet.JsonLocalizer.Test.Helpers;
+using Microsoft.Extensions.Localization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections;
+using System.Globalization;
+using System.Linq;
+using Askmethat.Aspnet.JsonLocalizer.JsonOptions;
+using LocalizedString = Microsoft.Extensions.Localization.LocalizedString;
+using System.IO;
+
+namespace Askmethat.Aspnet.JsonLocalizer.Test.Localizer
+{
+    [TestClass]
+    public class MissingTranslationTest
+    {
+        private JsonStringLocalizer localizer = null;
+        public void InitLocalizer(string cultureString)
+        {
+            SetCurrentCulture(cultureString);
+
+            localizer = JsonStringLocalizerHelperFactory.Create(new JsonLocalizationOptions()
+            {
+                DefaultCulture = new CultureInfo("en-AU"),
+                MissingTranslationLogBehavior = Extensions.MissingTranslationLogBehavior.CollectToJSON,
+                SupportedCultureInfos = new System.Collections.Generic.HashSet<CultureInfo>()
+                {
+                     new CultureInfo("fr"),
+                     new CultureInfo("en"),
+                     new CultureInfo("zh-CN"),
+                     new CultureInfo("en-AU")
+                },
+                ResourcesPath = $"{AppContext.BaseDirectory}/i18nFallback",
+                LocalizationMode = LocalizationMode.I18n
+            });
+        }
+
+        [TestMethod]
+        public void Should_Track_Colored_NotFound()
+        {
+            var defaultJsonFile = JsonLocalizationOptions.DEFAULT_MISSING_TRANSLATIONS;
+            if (File.Exists(defaultJsonFile))
+                File.Delete(defaultJsonFile);
+            InitLocalizer("en-AU");
+            var result = localizer.GetString("Colored",false);
+            Assert.IsTrue(result.ResourceNotFound);
+            localizer.Dispose();
+            Assert.IsTrue(File.Exists(defaultJsonFile));
+        }
+
+        /// <summary>
+        /// LocalizedString doesn't implement the IComparer interface required by CollectionAssert.AreEqual(), so providing one here
+        /// </summary>
+        private class LocalizedStringComparer : IComparer
+        {
+            public int Compare(object x, object y)
+            {
+                LocalizedString lsX = (LocalizedString)x;
+                LocalizedString lsY = (LocalizedString)y;
+                if (ReferenceEquals(lsX, lsY))
+                {
+                    return 0;
+                }
+                if (lsX.Name == lsY.Name && lsX.Value == lsY.Value && lsX.ResourceNotFound == lsY.ResourceNotFound)
+                {
+                    return 0;
+                }
+                int result = StringComparer.CurrentCulture.Compare(lsX.Name, lsY.Name);
+                if (result != 0)
+                {
+                    return result;
+                }
+                result = StringComparer.CurrentCulture.Compare(lsX.Value, lsY.Value);
+                return result != 0 ? result : lsX.ResourceNotFound.CompareTo(lsY.ResourceNotFound);
+            }
+        }
+
+        private void SetCurrentCulture(string cultureName)
+            => SetCurrentCulture(new CultureInfo(cultureName));
+
+        private void SetCurrentCulture(CultureInfo cultureInfo)
+            => CultureInfo.CurrentUICulture = cultureInfo;
+    }
+}


### PR DESCRIPTION
Added new option MissingTranslationLogBehavior = MissingTranslationLogBehavior.CollectToJSON that enables to track all the missing translations and write them on dispose into a json file. 

The objective of this change is to simplify the process for translating an app. If you run the native language through the localizer (instead of keys), write this to json, you can generate almost all the localized text automatically.