### PR TITLE
change strict parsing of json files

### DIFF
--- a/Askmethat.Aspnet.JsonLocalizer.Shared/Localizer/Modes/LocalisationModeHelpers.cs
+++ b/Askmethat.Aspnet.JsonLocalizer.Shared/Localizer/Modes/LocalisationModeHelpers.cs
@@ -12,7 +12,7 @@ namespace Askmethat.Aspnet.JsonLocalizer.Localizer.Modes
         {
             return 
                 JsonSerializer.Deserialize<ConcurrentDictionary<T, U>>(
-                    File.ReadAllText(file, encoding));
+                    File.ReadAllText(file, encoding), new JsonSerializerOptions() { ReadCommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true});
         }
     }
 }

--- a/Askmethat.Aspnet.JsonLocalizer.Shared/Localizer/Modes/LocalizationI18NModeGenerator.cs
+++ b/Askmethat.Aspnet.JsonLocalizer.Shared/Localizer/Modes/LocalizationI18NModeGenerator.cs
@@ -70,9 +70,11 @@ namespace Askmethat.Aspnet.JsonLocalizer.Localizer.Modes
             return localization;
         }
 
+        private static readonly JsonDocumentOptions Options = new JsonDocumentOptions() { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true };
+
         internal void AddValueToLocalization(JsonLocalizationOptions options, string file, bool isParent)
         {
-            using var doc = JsonDocument.Parse(File.ReadAllText(file, options.FileEncoding));
+            using var doc = JsonDocument.Parse(File.ReadAllText(file, options.FileEncoding), Options);
             if (doc is null)
             {
                 return;

--- a/test/Askmethat.Aspnet.JsonLocalizer.Test/encoding/localization.json
+++ b/test/Askmethat.Aspnet.JsonLocalizer.Test/encoding/localization.json
@@ -3,6 +3,7 @@
     "Values": {
       "en-US": "My Name 1",
       "fr-FR": "Mon Nom 1",
+      // also comments are supported in json files
       "pt-PT": "Eu so joão"
     }
   },

--- a/test/Askmethat.Aspnet.JsonLocalizer.Test/i18n/localization.en-US.json
+++ b/test/Askmethat.Aspnet.JsonLocalizer.Test/i18n/localization.en-US.json
@@ -2,6 +2,7 @@
   "Name": "Name",
   "Color": "Color",
   "Restricted": {
+    //test for reading hierarchy and comments should be allowed
     "Sentence": "You are not available is this area"
   }
 }


### PR DESCRIPTION
minor fix to support comments in json files. Comments were ignored by newtonsoft.json but out of the box, System.Text.Json doesn't allow them. These changes let user put comments - which will be ignored and also lets users leave training commas.